### PR TITLE
input -> raw_input

### DIFF
--- a/PP4E/System/Processes/pipes-testchild.py
+++ b/PP4E/System/Processes/pipes-testchild.py
@@ -5,7 +5,7 @@ sys.stderr.write('Child %d of %d got arg: "%s"\n' %
                                 (mypid, parentpid, sys.argv[1]))
 for i in range(2):
     time.sleep(3)              # make parent process wait by sleeping here
-    recv = input()             # stdin tied to pipe: comes from parent's stdout
+    recv = raw_input()             # stdin tied to pipe: comes from parent's stdout
     time.sleep(3)
     send = 'Child %d got: [%s]' % (mypid, recv)
     print(send)                # stdout tied to pipe: goes to parent's stdin

--- a/PP4E/System/Processes/pipes.py
+++ b/PP4E/System/Processes/pipes.py
@@ -33,7 +33,7 @@ if __name__ == '__main__':
 
     print('Hello 1 from parent', mypid)               # to child's stdin
     sys.stdout.flush()                                # subvert stdio buffering
-    reply = input()                                   # from child's stdout
+    reply = raw_input()                                   # from child's stdout
     sys.stderr.write('Parent got: "%s"\n' % reply)    # stderr not tied to pipe!
 
     print('Hello 2 from parent', mypid)


### PR DESCRIPTION
may be raw_input()
because with input() die:
Traceback (most recent call last):
  File "pipes.py", line 36, in <module>
    reply = input()  # from child's stdout
  File "<string>", line 1
    Child 8251 got: [('Hello 1 from parent', 8250)]
